### PR TITLE
Using assetpack for fewer roundtrips to the server and to avoid cloudflare caching issues

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ WriteMakefile(
     'Mojolicious'                 => '6.00',
     'Mojo::Pg'                    => '1.10',
     'Mojolicious::Plugin::OAuth2' => '1.50',
+    'Mojolicious::Plugin::AssetPack' => '0.39',
   },
   test => {TESTS        => 't/*.t'},
 );

--- a/cpanfile
+++ b/cpanfile
@@ -3,4 +3,5 @@ requires 'DBD::Pg'                     => '3.4.2';
 requires 'Mojolicious'                 => '6.00';
 requires 'Mojo::Pg'                    => '1.10';
 requires 'Mojolicious::Plugin::OAuth2' => '1.50';
+requires 'Mojolicious::Plugin::AssetPack' => '0.39';
 test_requires 'Test::More' => '0.88';

--- a/lib/MCT.pm
+++ b/lib/MCT.pm
@@ -19,6 +19,7 @@ sub startup {
   my $app = shift;
 
   $app->plugin('Config' => file => $ENV{MOJO_CONFIG} || $app->home->rel_file('mct.conf'));
+  $app->plugin('AssetPack');
   $app->plugin('MCT::Plugin::Auth');
 
   $app->helper('model.db'           => sub { $_[0]->stash->{'mct.db'} ||= $_[0]->app->pg->db });
@@ -27,10 +28,22 @@ sub startup {
   $app->helper('model.presentation' => sub { MCT::Model->new_object(Presentation => db => shift->model->db, @_) });
   $app->helper('model.user'         => sub { MCT::Model->new_object(User => db => shift->model->db, @_) });
 
+  $app->_assets;
   $app->_setup_database;
   $app->_setup_secrets;
   $app->_setup_validation;
   $app->_routes;
+}
+
+sub _assets {
+  my $app = shift;
+
+  $app->asset('mojoconf.css' => (
+    'http://fonts.googleapis.com/css?family=Oswald:400,300,700',
+    'http://fonts.googleapis.com/css?family=PT+Sans+Narrow',
+    'http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css',
+    '/css/main.css',
+  ));
 }
 
 sub _routes {

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -25,13 +25,7 @@
     <!--<![endif]-->
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/pure-min.css">
-    %= stylesheet '/css/main.css'
-    <link href='//fonts.googleapis.com/css?family=Oswald:400,300,700' rel='stylesheet' type='text/css'>
-    <link href='//fonts.googleapis.com/css?family=PT+Sans+Narrow' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-
-    <script src="//use.typekit.net/kyp4lea.js"></script>
-    <script>try{Typekit.load();}catch(e){}</script>
+    %= asset 'mojoconf.css'
   </head>
   <body>
     %= content
@@ -45,7 +39,6 @@
 
       ga('create', '<%= $conference->analytics_code %>', 'auto');
       ga('send', 'pageview');
-
     </script>
   % }
   </body>


### PR DESCRIPTION
To make changes to the assets while developing, I suggest setting `MOJO_ASSETPACK_NO_CACHE=1`, which will generate a new asset on each request.

The nice thing about using an assetpack, is that it generates a new name for the resource on each change, so the users on the other end will be forced to download a new asset.

Browsers will probably not download a new version of main.css, even if you change v=1 to v=2:

```
<link rel="stylesheet" href="/css/main.css?v=1">
```

Assetpack on the other hand generates an asset with a checksum, so the browser need to download a new file when something has changed:

```
<link rel="stylesheet" href="/packed/mojoconf-ae57ff942b380f98ca4b717d58e9f6ce.css">
```
