### PR TITLE
Submit talk from call for papers site force auth, fixes #40

### DIFF
--- a/lib/MCT/Controller/Presentation.pm
+++ b/lib/MCT/Controller/Presentation.pm
@@ -20,13 +20,11 @@ sub show {
 
 sub edit {
   my $c = shift;
-  return $c->render('presentation/edit')
-    unless my $url_name = $c->stash('url_name');
-
   my $p = $c->model->presentation(
     conference => $c->stash('conference')->identifier,
-    url_name   => $url_name,
+    url_name   => $c->stash('url_name'),
   );
+
   $c->delay(
     sub { $p->load(shift->begin) },
     sub {
@@ -49,7 +47,9 @@ sub store {
   );
 
   # if validation fails, render the edit page
-  return $c->edit if $p->validate($validation)->has_error;
+  if ($p->validate($validation)->has_error) {
+    return $c->render('presentation/edit', p => $p);
+  }
 
   my $set = $validation->output;
   $set->{author} = $c->session('username');

--- a/t/update_presentation.t
+++ b/t/update_presentation.t
@@ -23,14 +23,15 @@ $t->app->model->conference(
   tagline => 'All the Mojo you can conf',
 )->save;
 
-$t->get_ok('/2015/presentations')
+$t->get_ok('/2015/user/presentations')
   ->status_is(200)
-  ->text_is('title' => 'Mojoconf 2015 - Submit a presentation')
-  ->element_exists('input[name="title"]')
-  ->element_exists('textarea[name="abstract"]');
+  ->text_is('title' => 'Mojoconf 2015 - My Presentations')
+  ->element_exists('form[action="/2015/user/presentations"][method="post"]')
+  ->element_exists('form input[name="title"]')
+  ->element_exists('form textarea[name="abstract"]');
 
 # test validation failure
-$t->post_ok('/2015/presentations', form => {})
+$t->post_ok('/2015/user/presentations', form => {})
   ->status_is(200)
   ->text_is('title' => 'Mojoconf 2015 - Submit a presentation')
   ->element_exists('input.field-with-error[name="title"]')
@@ -41,7 +42,7 @@ my $pres = {
   abstract => 'My content here',
 };
 my $location = '/2015/presentations/my-title';
-$t->post_ok('/2015/presentations', form => $pres)
+$t->post_ok('/2015/user/presentations', form => $pres)
   ->status_is(302)
   ->header_is('Location' => $location);
 
@@ -62,7 +63,7 @@ $t->get_ok("$location/edit")
 $pres->{id} = $t->tx->res->dom->at('input[name="id"]')->{value};
 $pres->{abstract} = 'New content here';
 
-$t->post_ok('/2015/presentations', form => $pres)
+$t->post_ok('/2015/user/presentations', form => $pres)
   ->status_is(302)
   ->header_is('Location' => $location);
 
@@ -77,7 +78,7 @@ $t->get_ok($location)
 $pres->{title} = 'Some New Title';
 my $new_location = '/2015/presentations/some-new-title';
 
-$t->post_ok('/2015/presentations', form => $pres)
+$t->post_ok('/2015/user/presentations', form => $pres)
   ->status_is(302)
   ->header_is('Location' => $new_location);
 
@@ -100,9 +101,7 @@ $t->get_ok("$new_location/edit")
 
 # attempt to update the presentation without permission
 my %bad = (%$pres, abstract => 'This is bad');
-$t->post_ok('/2015/presentations', form => \%bad)
-  ->status_is(401)
-  ->content_is('Not authorized');
+$t->post_ok('/2015/user/presentations', form => \%bad)->status_is(302)->header_like(Location => qr{/oauth/});
 
 $t->get_ok($new_location)
   ->status_is(200)

--- a/t/web-user-presentations.t
+++ b/t/web-user-presentations.t
@@ -14,20 +14,20 @@ $t->app->model->conference(name => 'Other conference')->save;
 
 $t->get_ok('/user/connect', form => {code => 42})->status_is(302);
 $t->get_ok('/all-the-presentations/user/presentations')->status_is(200)
-  ->text_is('section > h3', 'No presentations')
+  ->text_is('section:nth-of-child(2) > h3', 'No presentations')
   ->element_exists_not('table');
 
 my $pres = { title => 'Extremely cool talk about users', abstract => 'My content here' };
-$t->post_ok('/all-the-presentations/presentations', form => $pres)->status_is(302);
+$t->post_ok('/all-the-presentations/user/presentations', form => $pres)->status_is(302);
 
 $pres->{title} = 'Another cool talk';
-$t->post_ok('/other-conference/presentations', form => $pres)->status_is(302);
+$t->post_ok('/other-conference/user/presentations', form => $pres)->status_is(302);
 
 $pres->{title} = 'Yet a talk';
-$t->post_ok('/other-conference/presentations', form => $pres)->status_is(302);
+$t->post_ok('/other-conference/user/presentations', form => $pres)->status_is(302);
 
 $t->get_ok('/all-the-presentations/user/presentations')->status_is(200)
-  ->text_is('section > h3', 'Your presentations')
+  ->text_is('section:nth-of-child(2) > h3', 'Your presentations')
   ->$_test_table([
     [
       'Other conference',

--- a/templates/2015/call.html.ep
+++ b/templates/2015/call.html.ep
@@ -35,7 +35,7 @@ following four categories:
 
 <br />
 
-%= link_to 'Submit Talk', 'conference.page', {page => 'presentations'}, class => "big-action pure-button pure-button-primary"
+%= link_to 'Submit Talk', 'user.presentations', class => "big-action pure-button pure-button-primary"
 
 <h3><i class="fa fa-file-text-o"></i>Paper Submission Deadline</h3>
 

--- a/templates/user/presentations.html.ep
+++ b/templates/user/presentations.html.ep
@@ -15,6 +15,16 @@
 <div class="content-wrapper">
   <div class="content">
     <section>
+      <h3><i class="fa fa-edit"></i>Submit presentation to <%= $conference->name %></h3>
+      <br>
+      %= form_for 'presentation.save' => method => post => begin
+        %= form_row(title => undef, 'Title');
+        %= form_row(abstract => undef, 'Abstract', text_area('abstract', style => 'height:200px'));
+        <div class="submit-row"><button>Submit</button></div>
+      % end
+    </section>
+
+    <section>
     % if (@$presentations) {
       <h3><i class="fa fa-list"></i>Your presentations</h3>
       <br>
@@ -36,10 +46,6 @@
       </table>
     % } else {
       <h3><i class="fa fa-edit"></i>No presentations</h3>
-      <p>
-        You haven't submitted any presentations. Do you want to give a
-        <%= link_to 'talk', 'presentations' %>?
-      </p>
     % }
     </section>
   </div>


### PR DESCRIPTION
Highlights
- Add `form_row()` helper
- Changed routes
  GET /:cid/presentations => /:cid/user/presentations
  POST /:cid/presentations => /:cid/user/presentations
  GET /:cid/presentations => TODO: Should probably list the presentations for a conference
- Embed create presentation form in user/presentations.html.ep

What I'm unsure about is if it's confusing to go directly to github's OAuth2 page, instead of getting some information first.
